### PR TITLE
feature/add-kernel-passthru

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -435,6 +435,16 @@
             {
               nativeBuildInputs = [pkgs.makeWrapper];
               meta.mainProgram = "jupyter-lab";
+              passthru = {
+                kernels = builtins.listToAttrs (
+                  builtins.map
+                  (k: {
+                    name = k.name;
+                    value = k;
+                  })
+                  kernelDerivations
+                );
+              };
             }
             (''
                 mkdir -p $out/bin


### PR DESCRIPTION
Cherry picked from https://github.com/tweag/jupyenv/pull/419 to pull the kernel passthru changes.

Allows us to link the kernelPaths, for solving some tools getting the kernelInfo only from ~/.local/jupyter/kernles or another place