### PR TITLE
IHaskell Codemirror syntax highlighting enable

### DIFF
--- a/kernels/available/haskell/default.nix
+++ b/kernels/available/haskell/default.nix
@@ -40,7 +40,8 @@
 in {
   inherit name displayName;
   language = "haskell";
-  argv = kernelspec.argv;
-  codemirrorMode = "haskell";
+  # See https://github.com/IHaskell/IHaskell/pull/1191
+  argv = kernelspec.argv ++ ["--codemirror" "Haskell"];
+  codemirrorMode = "Haskell";
   logo64 = ./logo64.png;
 }


### PR DESCRIPTION
I can only get Codemirror working if I add the `--codemirror Haskell` kernel commandline arg.

Resolves #438