### PR TITLE
Document ModuleNotFoundError

### DIFF
--- a/docs/documentation/how-to.md
+++ b/docs/documentation/how-to.md
@@ -188,7 +188,7 @@ kernel.python.python-with-numpy.projectDir = ./my-custom-python;
     to your kernel.
 
     ```nix title="kernels.nix"
-    kernel.python.python-with-numpy.overrides = overrides.nix;
+    kernel.python.python-with-numpy.overrides = ./overrides.nix;
     ```
 
     Start the jupyter environment with `nix run`.

--- a/docs/documentation/how-to.md
+++ b/docs/documentation/how-to.md
@@ -184,11 +184,11 @@ kernel.python.python-with-numpy.projectDir = ./my-custom-python;
     ```
 
     Note we used `"pathspec"` here as that was the package which generated the
-    error and `final.flit-core` as that was the missing module.Add the override
+    error and `final.flit-core` as that was the missing module. Add the override
     to your kernel.
 
     ```nix title="kernels.nix"
-    kernel.python.python-with-numpy.overrides = ./overrides.nix;
+    kernel.python.<yourKernelName>.overrides = ./overrides.nix;
     ```
 
     Start the jupyter environment with `nix run`.


### PR DESCRIPTION
Poetry does not lock down information about the build system used to build dependencies. As such poetry2nix cannot automatically figure out build inputs. https://github.com/nix-community/poetry2nix/issues/568

This documents how to help poetry2nix out with figuring out build inputs such as the issue in  #442